### PR TITLE
fix: prepend root_path to openapi.json

### DIFF
--- a/src/nmtfast/auth/v1/docs.py
+++ b/src/nmtfast/auth/v1/docs.py
@@ -12,7 +12,7 @@ client_secret field for chosen OAuth2 flow types.
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.openapi.docs import (
     get_swagger_ui_html,
     get_swagger_ui_oauth2_redirect_html,
@@ -21,7 +21,8 @@ from fastapi.responses import HTMLResponse
 
 
 def _build_hide_client_secret_css(flow_types: list[str]) -> str:
-    """Build CSS hiding client_secret for chosen OAuth2 flow types.
+    """
+    Build CSS hiding client_secret for chosen OAuth2 flow types.
 
     Build a <style> block that hides the client_secret row in the
     Swagger UI authorization modal for the given OAuth2 flow types.
@@ -79,14 +80,19 @@ def register_swagger_ui(
     )
 
     @app.get("/docs", include_in_schema=False)
-    async def custom_swagger_ui_html() -> HTMLResponse:
+    async def custom_swagger_ui_html(request: Request) -> HTMLResponse:
         """
         Serve Swagger UI with optional CSS overrides injected.
         """
+        root = request.scope.get("root_path", "").rstrip("/")
+        openapi_url = root + (app.openapi_url or "/openapi.json")
+        oauth2_redirect_url = app.swagger_ui_oauth2_redirect_url
+        if oauth2_redirect_url:
+            oauth2_redirect_url = root + oauth2_redirect_url
         html_response = get_swagger_ui_html(
-            openapi_url=app.openapi_url or "/openapi.json",
+            openapi_url=openapi_url,
             title=f"{app.title} - Swagger UI",
-            oauth2_redirect_url=app.swagger_ui_oauth2_redirect_url,
+            oauth2_redirect_url=oauth2_redirect_url,
             init_oauth=app.swagger_ui_init_oauth,
             swagger_ui_parameters=app.swagger_ui_parameters,
         )

--- a/tests/auth/v1/test_docs.py
+++ b/tests/auth/v1/test_docs.py
@@ -102,3 +102,37 @@ def test_register_swagger_ui_no_css_by_default(docs_app: FastAPI):
     resp = client.get("/docs")
     body = resp.text
     assert "client_secret_authorizationCode" not in body
+
+
+def test_register_swagger_ui_no_oauth2_redirect_url():
+    """
+    When swagger_ui_oauth2_redirect_url is None the /docs endpoint should still
+    return 200 and the oauth2RedirectUrl line should not appear in the HTML.
+    """
+    no_redirect_app = FastAPI(
+        title="test-app",
+        docs_url=None,
+        swagger_ui_oauth2_redirect_url=None,
+    )
+    register_swagger_ui(no_redirect_app)
+    client = TestClient(no_redirect_app)
+    resp = client.get("/docs")
+    assert resp.status_code == 200
+    assert "oauth2RedirectUrl" not in resp.text
+
+
+def test_register_swagger_ui_prepends_root_path():
+    """
+    If the app has a root_path set, the /docs HTML should have the openapi_url
+    and oauth2_redirect_url correctly prefixed with the root path.
+    """
+    root_app = FastAPI(
+        title="test-app",
+        docs_url=None,
+        root_path="/some/root/path",
+    )
+    register_swagger_ui(root_app)
+    client = TestClient(root_app, root_path="/some/root/path")
+    resp = client.get("/docs")
+    body = resp.text
+    assert "url: '/some/root/path/openapi.json'" in body


### PR DESCRIPTION
Need root_path to precede openapi.json URL.

Refs: #51