### PR TITLE
feat: add task persistence fields and widget history API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+# Agent Instructions
+
+## Purpose
+- This repo is the shared nmtfast library used by the sibling application repos.
+- Put reusable auth, cache, HTMX, middleware, retry, settings, logging, task, discovery, error, and repository helpers here.
+- Keep the package app-agnostic and reusable across multiple apps.
+
+## Primary Goal
+- Find the smallest owning package for the requested behavior and edit there first.
+- Prefer additive, reusable changes over app-specific shortcuts.
+- Mirror package changes with tests in the corresponding tests/ path.
+
+## Python Standards
+- PEP 8: Ensure code follows standard conventions for indention, line length, naming, imports, blank lines, etc.
+- PEP 420 (implicit namespace packages): NEVER create `__init__.py` files. The project uses implicit namespace packages. Package directories exist without `__init__.py`.
+- PEP 585 (built-in generic types): Use `list[str]`, `dict[str, int]`, etc. instead of `typing.List`, `typing.Dict`.
+- PEP 484 (type hints): All non-test code must have PEP 484 compliant type hints.
+- PEP 257 (Google style docstrings): All functions and classes must have Google-style docstrings with `"""` on their own lines.
+
+## Hard Rules
+- Do not import application code from sibling repos into this library.
+- Do not add app-specific routes, templates, settings names, or business workflows here.
+- Preserve public APIs when possible. Prefer additive changes over breaking ones.
+- Prefer extending an existing v1 package over creating a parallel top-level namespace.
+- Keep helpers generic enough to serve multiple callers, not just the current app.
+- If a behavior is only needed by one app, keep it in that app repo instead of moving it here.
+
+## Key Paths
+- pyproject.toml: Poetry dependencies and tool configuration.
+- src/nmtfast/auth/v1/: Authentication helpers and policies.
+- src/nmtfast/cache/v1/: Cache helpers and integrations.
+- src/nmtfast/discovery/v1/: Discovery and registration helpers.
+- src/nmtfast/errors/v1/: Shared error types and helpers.
+- src/nmtfast/htmx/v1/: HTMX helpers and response utilities.
+- src/nmtfast/logging/v1/: Logging helpers.
+- src/nmtfast/middleware/v1/: Reusable middleware.
+- src/nmtfast/repositories/gadgets/: Shared gadget repository helpers.
+- src/nmtfast/repositories/widgets/: Shared widget repository helpers.
+- src/nmtfast/retry/v1/: Retry utilities.
+- src/nmtfast/settings/v1/: Shared settings and configuration helpers.
+- src/nmtfast/tasks/v1/: Shared task helpers and integrations.
+- tests/: Test tree mirrors src/nmtfast/.
+- tests/auth/: Authentication tests.
+- tests/cache/: Cache tests.
+- tests/discovery/: Discovery tests.
+- tests/errors/: Error tests.
+- tests/htmx/: HTMX helper tests.
+- tests/logging/: Logging tests.
+- tests/middleware/: Middleware tests.
+- tests/repositories/: Shared repository helper tests.
+- tests/retry/: Retry tests.
+- tests/settings/: Settings tests.
+- tests/tasks/: Task tests.
+
+## How To Route Changes
+- Authentication behavior: start in src/nmtfast/auth/v1/.
+- Cache behavior: start in src/nmtfast/cache/v1/.
+- Discovery or registration behavior: start in src/nmtfast/discovery/v1/.
+- Shared HTMX helpers: start in src/nmtfast/htmx/v1/.
+- Logging, middleware, retry, settings, or task helpers: start in the matching src/nmtfast/*/v1/ package.
+- Shared repository adapters or helper clients: start in src/nmtfast/repositories/.
+- Shared error contracts or error translation: start in src/nmtfast/errors/v1/.
+- If a proposed change needs app-specific branching, stop and keep that behavior in the app repo instead.
+
+## Test Mapping
+- src/nmtfast/auth/ -> tests/auth/
+- src/nmtfast/cache/ -> tests/cache/
+- src/nmtfast/discovery/ -> tests/discovery/
+- src/nmtfast/errors/ -> tests/errors/
+- src/nmtfast/htmx/ -> tests/htmx/
+- src/nmtfast/logging/ -> tests/logging/
+- src/nmtfast/middleware/ -> tests/middleware/
+- src/nmtfast/repositories/ -> tests/repositories/
+- src/nmtfast/retry/ -> tests/retry/
+- src/nmtfast/settings/ -> tests/settings/
+- src/nmtfast/tasks/ -> tests/tasks/
+- Add new tests for new shared behavior and update existing tests when behavior changes.
+
+## Workspace Boundaries
+- nmt-fastapi-library/: Reusable cross-app infrastructure belongs here.
+- ../nmt-fastapi-reference/: Backend API-specific behavior stays there.
+- ../nmt-fastapi-reference-web/: Web UI, HTMX page flows, and templates stay there.
+- Do not move app-specific logic into this repo just to avoid duplication in a single change.
+
+## Conventions That Matter Most
+- Design for reuse across apps instead of the current caller only.
+- Keep public APIs stable unless the requested change requires a breaking change.
+- Prefer versioned modules under v1/ for new shared functionality when the existing structure allows it.
+- Keep external integrations wrapped behind narrow helpers or adapters.
+- Tool-driven docstring, lint, and type-check behavior are defined by pyproject.toml and the commands below.
+
+## Validation Workflow
+- Prefer poetry run commands instead of relying on shell activation state.
+- During iteration, run the narrowest relevant pytest target for the touched package first.
+- After the first passing focused test, run the full project test suite.
+- If you add or change Python code, also run coverage, lint, and type checks before finishing.
+- If you change a shared public surface, make sure tests cover both success and failure behavior.
+
+## Commands
+- Activate local environment: source .venv/Scripts/activate || source .venv/bin/activate
+- Focused tests: poetry run pytest tests/path/to/test_file.py -k expression
+- Full tests: poetry run pytest
+- Coverage: poetry run pytest --cov --cov-report term-missing tests
+- Lint: poetry run invoke lint
+- Fix formatting and imports: poetry run invoke fixers
+- Type hints: poetry run invoke mypy

--- a/src/nmtfast/repositories/gadgets/v1/schemas.py
+++ b/src/nmtfast/repositories/gadgets/v1/schemas.py
@@ -28,6 +28,8 @@ class GadgetRead(GadgetBase):
     """Schema for reading a gadget, including additional attributes."""
 
     id: str
+    last_task_uuid: Optional[str] = None
+    last_task_status: Optional[str] = None
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -55,6 +57,6 @@ class GadgetZapTask(BaseModel):
 
     uuid: str
     state: str = "UNKNOWN"
-    id: str
+    gadget_id: str
     duration: int
     runtime: int

--- a/src/nmtfast/repositories/widgets/v1/api.py
+++ b/src/nmtfast/repositories/widgets/v1/api.py
@@ -18,6 +18,7 @@ from nmtfast.repositories.widgets.v1.schemas import (
     WidgetUpdate,
     WidgetZap,
     WidgetZapTask,
+    WidgetZapTaskRead,
 )
 from nmtfast.retry.v1.tenacity import tenacity_retry_log
 
@@ -381,3 +382,70 @@ class WidgetApiRepository:
         logger.debug(f"Bulk updated {updated} widgets")
 
         return updated
+
+    @retry(
+        reraise=True,
+        stop=stop_after_attempt(5),
+        wait=wait_fixed(0.2),
+        after=tenacity_retry_log(logger),
+    )
+    async def widget_zap_history(
+        self,
+        widget_id: int,
+        page: int = 1,
+        page_size: int = 10,
+        sort_by: str = "created_at",
+        sort_order: Literal["asc", "desc"] = "desc",
+        search: str | None = None,
+    ) -> tuple[list[WidgetZapTaskRead], PaginationMeta]:
+        """
+        Retrieve zap task history for a widget through the API.
+
+        Args:
+            widget_id: The ID of the widget.
+            page: The page number to retrieve (1-indexed).
+            page_size: The number of items per page.
+            sort_by: The field name to sort by.
+            sort_order: The sort direction ('asc' or 'desc').
+            search: Optional search filter string.
+
+        Returns:
+            tuple[list[WidgetZapTaskRead], PaginationMeta]: A list of task history
+                records and pagination metadata.
+
+        Raises:
+            WidgetApiException: Raised when upstream API reports failure status code.
+        """
+        logger.debug(f"Fetching zap history for widget ID {widget_id}")
+        params: dict[str, str | int] = {
+            "page": page,
+            "page_size": page_size,
+            "sort_by": sort_by,
+            "sort_order": sort_order,
+        }
+        if search:
+            params["search"] = search
+        resp = await self.api_client.get(
+            f"/v1/widgets/{widget_id}/zap",
+            params=params,
+        )
+
+        if resp.status_code != 200:
+            logger.info(f"Failed to get zap history: {resp.status_code}: {resp.text}")
+            raise WidgetApiException(resp)
+
+        tasks = [WidgetZapTaskRead(**t) for t in resp.json()]
+        total = int(resp.headers.get("X-Total-Count", len(tasks)))
+        pagination = PaginationMeta(
+            total=total,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            search=search,
+        )
+        logger.debug(
+            f"Retrieved {len(tasks)} zap tasks for widget {widget_id} (total: {total})"
+        )
+
+        return tasks, pagination

--- a/src/nmtfast/repositories/widgets/v1/schemas.py
+++ b/src/nmtfast/repositories/widgets/v1/schemas.py
@@ -4,9 +4,10 @@
 
 """Pydantic schemas for interacting with the widgets API."""
 
+from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class WidgetBase(BaseModel):
@@ -27,7 +28,13 @@ class WidgetCreate(WidgetBase):
 class WidgetRead(WidgetBase):
     """Schema for reading a widget, including additional attributes."""
 
-    id: int
+    id: int = Field(..., description="Database ID of the widget.")
+    last_task_uuid: str | None = Field(
+        None, description="UUID of the most recent zap task."
+    )
+    last_task_status: str | None = Field(
+        None, description="Status of the most recent zap task."
+    )
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -55,6 +62,28 @@ class WidgetZapTask(BaseModel):
 
     uuid: str
     state: str = "UNKNOWN"
-    id: int
+    widget_id: int
     duration: int
     runtime: int
+    result: dict | None = None
+
+
+class WidgetZapTaskRead(BaseModel):
+    """Schema for a persisted zap task history record."""
+
+    task_uuid: str
+    state: str = "UNKNOWN"
+    widget_id: int
+    duration: int
+    runtime: int
+    result: dict | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class WidgetZapTasksResponse(BaseModel):
+    """Response containing a list of zap task history records."""
+
+    tasks: list[WidgetZapTaskRead] = Field(
+        ..., description="List of zap task history records."
+    )

--- a/tests/repositories/gadgets/v1/test_api.py
+++ b/tests/repositories/gadgets/v1/test_api.py
@@ -292,7 +292,7 @@ async def test_gadget_zap_success(fake_api_client):
     mock_response = GadgetZapTask(
         uuid="uuid-123",
         state="PENDING",
-        id="g1",
+        gadget_id="g1",
         duration=10,
         runtime=0,
     ).model_dump()
@@ -331,7 +331,7 @@ async def test_gadget_zap_by_uuid_success(fake_api_client):
     mock_response_data = GadgetZapTask(
         uuid="uuid-456",
         state="SUCCESS",
-        id="g1",
+        gadget_id="g1",
         duration=10,
         runtime=123,
     ).model_dump()

--- a/tests/repositories/widgets/v1/test_api.py
+++ b/tests/repositories/widgets/v1/test_api.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 
+from nmtfast.htmx.v1.schemas import PaginationMeta
 from nmtfast.repositories.widgets.v1.api import WidgetApiRepository
 from nmtfast.repositories.widgets.v1.exceptions import WidgetApiException
 from nmtfast.repositories.widgets.v1.schemas import (
@@ -17,6 +18,7 @@ from nmtfast.repositories.widgets.v1.schemas import (
     WidgetUpdate,
     WidgetZap,
     WidgetZapTask,
+    WidgetZapTaskRead,
 )
 
 
@@ -107,7 +109,7 @@ async def test_widget_zap_success(fake_api_client):
     mock_response = WidgetZapTask(
         uuid="uuid-123",
         state="PENDING",
-        id=1,
+        widget_id=1,
         duration=10,
         runtime=0,
     ).model_dump()
@@ -138,6 +140,94 @@ async def test_widget_zap_failure_raises(fake_api_client):
 
 
 @pytest.mark.asyncio
+async def test_widget_zap_history_success(fake_api_client):
+    """
+    Test successful widget_zap_history.
+    """
+    repo = WidgetApiRepository(fake_api_client)
+    mock_list = [
+        {
+            "task_uuid": "task-1",
+            "state": "SUCCESS",
+            "widget_id": 1,
+            "duration": 10,
+            "runtime": 100,
+            "result": None,
+        },
+        {
+            "task_uuid": "task-2",
+            "state": "PENDING",
+            "widget_id": 1,
+            "duration": 10,
+            "runtime": 0,
+            "result": None,
+        },
+    ]
+
+    resp = httpx.Response(status_code=200, json=mock_list)
+    resp.json = lambda **kwargs: mock_list
+    resp.headers["X-Total-Count"] = "2"
+    fake_api_client.get.return_value = resp
+
+    tasks, pagination = await repo.widget_zap_history(1)
+    assert len(tasks) == 2
+    assert isinstance(tasks[0], WidgetZapTaskRead)
+    assert tasks[0].task_uuid == "task-1"
+    assert tasks[1].task_uuid == "task-2"
+    assert isinstance(pagination, PaginationMeta)
+    assert pagination.total == 2
+    assert pagination.page == 1
+    assert pagination.page_size == 10
+    assert pagination.sort_by == "created_at"
+    assert pagination.sort_order == "desc"
+
+
+@pytest.mark.asyncio
+async def test_widget_zap_history_with_search(fake_api_client):
+    """
+    Test widget_zap_history passes search parameter.
+    """
+    repo = WidgetApiRepository(fake_api_client)
+    mock_list = [
+        {
+            "task_uuid": "task-3",
+            "state": "FAILED",
+            "widget_id": 1,
+            "duration": 5,
+            "runtime": 200,
+            "result": {},
+        }
+    ]
+
+    resp = httpx.Response(status_code=200, json=mock_list)
+    resp.json = lambda **kwargs: mock_list
+    resp.headers["X-Total-Count"] = "1"
+    fake_api_client.get.return_value = resp
+
+    tasks, pagination = await repo.widget_zap_history(1, search="FAILED")
+    assert len(tasks) == 1
+    assert tasks[0].state == "FAILED"
+    call_kwargs = fake_api_client.get.call_args
+    assert call_kwargs.kwargs["params"]["search"] == "FAILED"
+    assert call_kwargs.kwargs["params"]["sort_by"] == "created_at"
+    assert call_kwargs.kwargs["params"]["sort_order"] == "desc"
+
+
+@pytest.mark.asyncio
+async def test_widget_zap_history_failure_raises(fake_api_client):
+    """
+    Test widget_zap_history raises WidgetApiException on failure.
+    """
+    repo = WidgetApiRepository(fake_api_client)
+    fake_api_client.get.return_value = httpx.Response(
+        status_code=500, text="Server error"
+    )
+
+    with pytest.raises(WidgetApiException):
+        await repo.widget_zap_history(999)
+
+
+@pytest.mark.asyncio
 async def test_widget_zap_by_uuid_success(fake_api_client):
     """
     Test successful widget_zap_by_uuid.
@@ -146,7 +236,7 @@ async def test_widget_zap_by_uuid_success(fake_api_client):
     mock_response_data = WidgetZapTask(
         uuid="uuid-456",
         state="SUCCESS",
-        id=1,
+        widget_id=1,
         duration=10,
         runtime=123,
     ).model_dump()


### PR DESCRIPTION
- Add last_task_uuid/last_task_status to GadgetRead and WidgetRead
- Rename ambiguous id field on ZapTask schemas to gadget_id/widget_id
- Introduce WidgetZapTaskRead and WidgetZapTasksResponse schemas
- Add result field to WidgetZapTask for storing task output
- Implement widget_zap_history API method with pagination, sorting,
search filtering, and retry logic
- Update existing gadget and widget zap tests for renamed fields
- Add tests covering success, search, and failure paths for history

Refs: #57