### PR TITLE
feat(auth): resolve JWT username claims in auth

### DIFF
--- a/src/nmtfast/auth/v1/acl.py
+++ b/src/nmtfast/auth/v1/acl.py
@@ -21,10 +21,13 @@ class AuthSuccess(BaseModel):
 
     Attributes:
         name: API Key or OAuth client name that was authenticated.
+        username: The resolved user identity extracted from JWT claims, or None
+            for non-user authentication methods (e.g., API keys).
         acls: List of section access control rules.
     """
 
     name: str
+    username: str | None = None
     acls: list[SectionACL]
 
     @field_serializer("acls")
@@ -71,19 +74,22 @@ async def check_acl(
         if section_regex and not re.match(section_regex, section):
             continue
 
+        user_label = acl.resolved_user_label or acl.principal_name
+
         # allow if the section matched, and * is in the and filters is empty
         if "*" in permissions and not filters:
-            logger.debug(
+            logger.info(
                 f"Allow '*' and empty filter list principal: "
-                f"{acl.principal_name} (memo: {acl.memo})"
+                f"{acl.principal_name} (user: {user_label} ; memo: {acl.memo})"
             )
             return True
 
         # allow if the specific permission is granted
         if "*" not in permissions and method in permissions:
-            logger.debug(
+            logger.info(
                 f"Allow method '{method}': permissions: {permissions} "
-                f"principal: {acl.principal_name} (memo: {acl.memo})"
+                f"principal: {acl.principal_name} (user: {user_label} ; "
+                f"memo: {acl.memo})"
             )
             return True
 
@@ -108,7 +114,8 @@ async def check_acl(
         #         return False  # filter specified a field that does not exist in the payload.
 
         logger.debug(
-            f"ACL '{acl.principal_name}' (memo: {acl.memo}) did not grant "
+            f"ACL '{acl.principal_name}' (user: {user_label} ; "
+            f"memo: {acl.memo}) did not grant "
             f"'{method}' permission for '{section}' section, trying next ACL"
         )
 

--- a/src/nmtfast/auth/v1/jwt.py
+++ b/src/nmtfast/auth/v1/jwt.py
@@ -184,6 +184,7 @@ def _resolve_group_acls(
     claims: dict,
     auth_settings: AuthSettings,
     provider: str,
+    username: str | None = None,
 ) -> list[SectionACL]:
     """
     Resolve ACLs from static group configurations by matching JWT group claims.
@@ -196,6 +197,8 @@ def _resolve_group_acls(
         claims: Decoded JWT claims.
         auth_settings: The auth section of app configuration.
         provider: The matched identity provider name.
+        username: Optional resolved human-readable username to stamp on each
+            group-granted ACL for audit logging.
 
     Returns:
         list[SectionACL]: Merged ACLs from all matching groups, or [] if none match.
@@ -218,11 +221,37 @@ def _resolve_group_acls(
             continue
         logger.debug(f"Matched static group '{group_name}'")
         group_acls.extend(
-            acl.model_copy(update={"principal_name": group_name})
+            acl.model_copy(
+                update={
+                    "principal_name": group_name,
+                    "resolved_user_label": username,
+                }
+            )
             for acl in group_conf.acls
         )
 
     return group_acls
+
+
+def _extract_username(claims: dict[str, str]) -> str | None:
+    """
+    Extract the human-readable username from JWT claims.
+
+    Tries common OIDC claim names in order of preference and returns the first
+    non-empty value found.
+
+    Args:
+        claims: Decoded JWT claims dictionary.
+
+    Returns:
+        str | None: The extracted username, or None if no claim matched.
+    """
+    for claim_name in ("preferred_username", "name", "email", "sub"):
+        value = claims.get(claim_name)
+        if value and isinstance(value, str) and len(value.strip()) > 0:
+            return value.strip()
+
+    return None
 
 
 async def authenticate_token(
@@ -288,9 +317,10 @@ async def authenticate_token(
 
     # resolve composite ACLs from static users and groups
     user_name, user_acls = _resolve_user_acls(claims, auth_settings, provider)
-    group_acls = _resolve_group_acls(claims, auth_settings, provider)
+    username = _extract_username(claims) if claims else None
+    group_acls = _resolve_group_acls(claims, auth_settings, provider, username)
 
     composite_acls: list[SectionACL] = auth_info["acls"] + user_acls + group_acls
     resolved_name: str = user_name if user_name else auth_info["name"]
 
-    return AuthSuccess(name=resolved_name, acls=composite_acls)
+    return AuthSuccess(name=resolved_name, username=username, acls=composite_acls)

--- a/src/nmtfast/settings/v1/schemas.py
+++ b/src/nmtfast/settings/v1/schemas.py
@@ -57,12 +57,15 @@ class SectionACL(BaseModel):
         permissions: List of granted permissions (e.g., ["read", "write"]).
         memo: Optional human-readable note describing this ACL entry.
         principal_name: auto-filled name of the principal (API key or OAuth client).
+        resolved_user_label: auto-filled human-readable username stamp for group-
+            granted ACLs, so audit logs can attribute access to the actual user.
     """
 
     section_regex: str
     permissions: list[str]
     memo: Optional[str] = None
     principal_name: Optional[str] = None  # NOTE: do not fill this manually
+    resolved_user_label: Optional[str] = None  # NOTE: auto-filled for group ACLs
     # TODO: add support for filters later
     # filters: list[FilterACL] = []
 

--- a/tests/auth/v1/test_jwt.py
+++ b/tests/auth/v1/test_jwt.py
@@ -15,6 +15,7 @@ from jwt import DecodeError, ExpiredSignatureError, InvalidTokenError
 from nmtfast.auth.v1.acl import AuthSuccess
 from nmtfast.auth.v1.exceptions import AuthenticationError, AuthorizationError
 from nmtfast.auth.v1.jwt import (
+    _extract_username,
     _resolve_group_acls,
     _resolve_user_acls,
     authenticate_token,
@@ -215,6 +216,7 @@ async def test_authenticate_token_success():
     mock_token = "valid.token"
     expected_auth_info = AuthSuccess(
         name="client1",
+        username="test-user",
         acls=[
             SectionACL(
                 section_regex=".*", permissions=["read"], principal_name="client1"
@@ -390,7 +392,9 @@ async def test_authenticate_token_multiple_clients():
             section_regex="specific", permissions=["write"], principal_name="client2"
         )
     ]
-    mock_auth_info = AuthSuccess(name="client2", acls=mock_acls)
+    mock_auth_info = AuthSuccess(
+        name="client2", username="correct-user", acls=mock_acls
+    )
 
     with (
         patch("nmtfast.auth.v1.jwt.get_idp_provider", return_value="test-idp"),
@@ -668,10 +672,11 @@ def test_resolve_group_acls_match():
         ),
     )
     claims = {"sub": "alice", "groups": ["netadmin", "users"]}
-    acls = _resolve_group_acls(claims, auth_settings, "test-idp")
+    acls = _resolve_group_acls(claims, auth_settings, "test-idp", username="alice")
     assert len(acls) == 1
     assert acls[0].permissions == ["*"]
     assert acls[0].principal_name == "netadmin"
+    assert acls[0].resolved_user_label == "alice"
 
 
 def test_resolve_group_acls_multiple_groups():
@@ -701,12 +706,13 @@ def test_resolve_group_acls_multiple_groups():
         ),
     )
     claims = {"sub": "alice", "groups": ["netadmin", "devops"]}
-    acls = _resolve_group_acls(claims, auth_settings, "test-idp")
+    acls = _resolve_group_acls(claims, auth_settings, "test-idp", username="alice")
     assert len(acls) == 2
     regexes = {a.section_regex for a in acls}
     assert regexes == {"^network$", "^deploy$"}
     principals = {a.principal_name for a in acls}
     assert principals == {"netadmin", "devops"}
+    assert all(a.resolved_user_label == "alice" for a in acls)
 
 
 def test_resolve_group_acls_no_groups_claim():
@@ -910,6 +916,7 @@ async def test_authenticate_token_composite_client_and_user():
     ):
         result = await authenticate_token("valid.token", auth_settings)
         assert result.name == "alice"
+        assert result.username == "alice-uuid"
         assert len(result.acls) == 2
         regexes = {a.section_regex for a in result.acls}
         assert regexes == {"^widgets$", "^admin$"}
@@ -960,11 +967,14 @@ async def test_authenticate_token_composite_client_and_groups():
     ):
         result = await authenticate_token("valid.token", auth_settings)
         assert result.name == "web_client"
+        assert result.username is None
         assert len(result.acls) == 2
         regexes = {a.section_regex for a in result.acls}
         assert regexes == {"^widgets$", "^network$"}
         principals = {a.principal_name for a in result.acls}
         assert principals == {"web_client", "netadmin"}
+        group_acl = next(a for a in result.acls if a.principal_name == "netadmin")
+        assert group_acl.resolved_user_label is None
 
 
 @pytest.mark.asyncio
@@ -1022,11 +1032,16 @@ async def test_authenticate_token_composite_all_sources():
     ):
         result = await authenticate_token("valid.token", auth_settings)
         assert result.name == "alice"
+        assert result.username == "alice-uuid"
         assert len(result.acls) == 4
         regexes = {a.section_regex for a in result.acls}
         assert regexes == {"^widgets$", "^admin$", "^network$", "^deploy$"}
         principals = {a.principal_name for a in result.acls}
         assert principals == {"web_client", "alice", "netadmin", "devops"}
+        group_acls = [
+            a for a in result.acls if a.principal_name in ("netadmin", "devops")
+        ]
+        assert all(a.resolved_user_label == "alice-uuid" for a in group_acls)
 
 
 @pytest.mark.asyncio
@@ -1062,6 +1077,59 @@ async def test_authenticate_token_backward_compat_no_users_no_groups():
     ):
         result = await authenticate_token("valid.token", auth_settings)
         assert result.name == "client1"
+        assert result.username == "test-user"
         assert len(result.acls) == 1
         assert result.acls[0].section_regex == ".*"
         assert result.acls[0].principal_name == "client1"
+
+
+# ---------------------------------------------------------------------------
+# Username extraction tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_username_preferred_username():
+    """Test that preferred_username is extracted when present."""
+    claims = {"preferred_username": "jdoe", "sub": "uuid-123"}
+    assert _extract_username(claims) == "jdoe"
+
+
+def test_extract_username_name_claim():
+    """Test fallback to name claim when preferred_username is absent."""
+    claims = {"name": "John Doe", "sub": "uuid-123"}
+    assert _extract_username(claims) == "John Doe"
+
+
+def test_extract_username_email_claim():
+    """Test fallback to email claim when preferred and name are absent."""
+    claims = {"email": "jdoe@example.com", "sub": "uuid-123"}
+    assert _extract_username(claims) == "jdoe@example.com"
+
+
+def test_extract_username_sub_claim():
+    """Test fallback to sub claim as last resort."""
+    claims = {"sub": "uuid-123"}
+    assert _extract_username(claims) == "uuid-123"
+
+
+def test_extract_username_empty_claims():
+    """Test that empty claims returns None."""
+    assert _extract_username({}) is None
+
+
+def test_extract_username_non_string_value():
+    """Test that non-string claim values are skipped."""
+    claims = {"preferred_username": 123, "sub": "uuid-123"}
+    assert _extract_username(claims) == "uuid-123"
+
+
+def test_extract_username_whitespace_only():
+    """Test that whitespace-only values are treated as empty."""
+    claims = {"preferred_username": "   ", "name": "Valid Name"}
+    assert _extract_username(claims) == "Valid Name"
+
+
+def test_extract_username_strips_whitespace():
+    """Test that leading/trailing whitespace is stripped."""
+    claims = {"preferred_username": "  jdoe  "}
+    assert _extract_username(claims) == "jdoe"


### PR DESCRIPTION
- Add username field to AuthSuccess for resolved user identity
- Add _extract_username helper probing preferred_username, name,
email, and sub claims in priority order
- Wire extracted username into authenticate_token return value
- Update existing JWT auth tests to assert username on results
- Add seven unit tests covering fallback order, empty claims,
non-string values, and whitespace stripping

Refs: #59